### PR TITLE
Streamline local builds setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ yarn-error.log
 /scripts/hak/**/*.js
 .DS_Store
 /artifacts
+/v*.*.*

--- a/build.ps1
+++ b/build.ps1
@@ -30,7 +30,6 @@ Confirm-And-Execute -CommandDescription "yarn install" -CommandBlock { yarn inst
 
 # step 2: yarn run fetch
 Confirm-And-Execute -CommandDescription 'yarn run fetch' -CommandBlock {
-    # yarn run fetch --noverify --cfgdir ".\element.io\release\"
     yarn run fetch --noverify --cfgdir ".\elecord.app\release\"
 }
 

--- a/local-builds.html
+++ b/local-builds.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <title>Local builds</title>
+    <style>
+        body {
+            font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.5;
+            max-width: 30em;
+            margin: 2em auto;
+            padding: 1em;
+            background-color: #222;
+            color: #eee;
+        }
+
+        h1 {
+            font-size: 2em;
+            margin-bottom: 0.5em;
+        }
+
+        a {
+            color: rgb(108, 180, 216);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        ol {
+            padding-left: 2em;
+        }
+
+        li {
+            margin-bottom: 0.5em;
+        }
+    </style>
+</head>
+
+<body>
+
+    <h1>Local builds</h1>
+    <p>Create builds locally using development versions of elecord-web.</p>
+
+    <ol>
+        <li>Download a webapp.zip from a recent GitHub workflow run
+            <br><a
+                href="https://github.com/elecordapp/elecord-web/actions">github.com/elecordapp/elecord-web/actions</a>
+        </li>
+        <li>Extract elecord-vb3a70e6-js-a29b873.tar.gz to <code>./v1.2.3/</code></li>
+        <li>Rename tarball to also match <code>elecord-v1.2.3.tar.gz</code></li>
+        <li>Edit <code>PACKAGE_URL_PREFIX</code> in <code>./scripts/fetch-package.ts</code></li>
+        <li>Start a live preview server from this file in vscode
+            <br><a
+                href="https://open-vsx.org/extension/ms-vscode/live-server">open-vsx.org/extension/ms-vscode/live-server</a>
+        </li>
+    </ol>
+
+</body>
+
+</html>
+

--- a/scripts/fetch-package.ts
+++ b/scripts/fetch-package.ts
@@ -11,7 +11,11 @@ import riotDesktopPackageJson from "../package.json";
 import { setPackageVersion } from "./set-version.js";
 
 const PUB_KEY_URL = "https://packages.riot.im/element-release-key.asc";
+
 const PACKAGE_URL_PREFIX = "https://github.com/elecordapp/elecord-web/releases/download/";
+// const PACKAGE_URL_PREFIX = "http://127.0.0.1:3000/";
+// (postfix: v1.0.0/elecord-v1.0.0.tar.gz)
+
 const DEVELOP_TGZ_URL = "https://develop.element.io/develop.tar.gz";
 const ASAR_PATH = "webapp.asar";
 


### PR DESCRIPTION
Creating local builds reliably has sometimes been an issue. This process helps ensure development builds stay as close to the release process as possible.