### PR TITLE
Update app identifiers to elecord

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -11,9 +11,9 @@ import { URL } from "node:url";
 import path from "node:path";
 import fs from "node:fs";
 
-const LEGACY_PROTOCOL = "element";
-const PROTOCOL = "io.element.desktop";
-const SEARCH_PARAM = "element-desktop-ssoid";
+const LEGACY_PROTOCOL = "elecord";
+const PROTOCOL = "app.elecord.desktop";
+const SEARCH_PARAM = "elecord-desktop-ssoid";
 const STORE_FILE_NAME = "sso-sessions.json";
 
 // we getPath userData before electron-main changes it, so this is the default value

--- a/src/webcontents-handler.ts
+++ b/src/webcontents-handler.ts
@@ -75,7 +75,7 @@ function onLinkContextMenu(ev: Event, params: ContextMenuParams, webContents: We
     if (url.startsWith("vector://vector/webapp")) {
         // Avoid showing a context menu for app icons
         if (params.hasImageContents) return;
-        const baseUrl = vectorConfig.web_base_url ?? "https://app.element.io/";
+        const baseUrl = vectorConfig.web_base_url ?? "https://web.elecord.app/";
         // Rewrite URL so that it can be used outside the app
         url = baseUrl + url.substring(23);
     }


### PR DESCRIPTION
Matches changes done in [elecord-web](https://github.com/elecordapp/elecord-web/pull/54).

MAS now displays elecord strings:

![Screenshot 2025-05-12 003517](https://github.com/user-attachments/assets/f45bc8e7-0364-4d63-a9d3-5a6d5ac5561f)
